### PR TITLE
Fallback on lincolnlogger

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,3 +4,4 @@ gem 'simplecov', :require => false, :group => :test           # MIT https://gith
 gem 'yard'                                                    # MIT https://github.com/lsegal/yard/blob/master/LICENSE + Ruby license for one file from the Ruby source lib/parser/ruby/legacy/ruby_lex.rb
 gem 'rspec'                                                   # MIT https://github.com/rspec/rspec/blob/master/License.txt
 gem 'byebug'
+gem "lincoln_logger", "~> 1.1"

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -10,6 +10,7 @@ GEM
     debugger-linecache (1.2.0)
     diff-lcs (1.2.5)
     docile (1.1.5)
+    lincoln_logger (1.1.0)
     multi_json (1.10.1)
     rspec (3.1.0)
       rspec-core (~> 3.1.0)
@@ -37,6 +38,7 @@ PLATFORMS
 DEPENDENCIES
   beaneater (~> 0.3, >= 0.3.3)
   byebug
+  lincoln_logger (~> 1.1)
   rspec
   simplecov
   yard

--- a/lib/refried/puter.rb
+++ b/lib/refried/puter.rb
@@ -144,7 +144,7 @@ module Refried
         begin
           logger.info message
         rescue => e
-          #puts "Failed to access logger, message that should have been logged = #{message}"
+          LincolnLogger.logger.info message
         end
       end
     end

--- a/lib/refried/puter.rb
+++ b/lib/refried/puter.rb
@@ -1,5 +1,5 @@
 require 'beaneater'
-
+require "lincoln_logger"
 module Refried
   module Puter
     module ActsAsPuter

--- a/refried.gemspec
+++ b/refried.gemspec
@@ -1,7 +1,7 @@
 Gem::Specification.new do |s|
   s.name        = 'refried'
-  s.version     = '0.0.6-rc7'
-  s.date        = '2015-01-02'
+  s.version     = '0.1.0'
+  s.date        = '2016-06-13'
   s.summary     = "Make Ruby objects behave like Beanstalk tubes"
   s.description = "Provides acts_as_ mixins for adding Beanstalk tube functionality to your existing Ruby objects."
   s.authors     = ["Courtland Caldwell"]
@@ -16,8 +16,9 @@ Gem::Specification.new do |s|
       "lib/refried/jobs.rb",
   ] # Remember don't add Rakefile or Gemfile to this list
   s.homepage    =
-      'https://github.com/caldwecr/refried'
+      'https://github.com/Referly/refried'
   s.add_runtime_dependency "beaneater", "~> 0.3", ">= 0.3.3"
+  s.add_runtime_dependency "lincoln_logger", "~> 1.1"
   s.add_development_dependency "simplecov", "~> 0.9"
   s.license     = "MIT"
 end


### PR DESCRIPTION
When we cannot infer the logger then fall back to lincoln logger. This is to accommodate some of the really early code.
